### PR TITLE
Remove sticky class from section headers

### DIFF
--- a/components/category-loop.php
+++ b/components/category-loop.php
@@ -17,9 +17,7 @@ return function (\shgysk8zer0\DOM\HTML $dom, \shgysk8zer0\Core\PDO $pdo, $page)
 			'class' => 'category',
 			// 'data-scroll-snap' => 'vertical',
 		]);
-		$header = $section->append('header', null, [
-			'class' => 'sticky',
-		]);
+		$header = $section->append('header');
 		$header->append('h2', null, ['class' => 'center'])->append('a', $cat->name, [
 			'href' => \KVSun\DOMAIN . $cat->url,
 		]);


### PR DESCRIPTION
## Make section headers not sticky. Fixes #14 
### List of significant changes made
-  Remove `sticky` from section headers.
-  


