### PR TITLE
Fix sidebar style on mobile

### DIFF
--- a/components/head.php
+++ b/components/head.php
@@ -131,7 +131,7 @@ return function (\shgysk8zer0\DOM\HTML $dom, \shgysk8zer0\Core\PDO $pdo, $page)
 	$head->append('link', null, [
 		'rel' => 'stylesheet',
 		'type' => 'text/css',
-		'href' => \KVSun\DEBUG ? \KVSun\DOMAIN . \KVSun\DEV_STYLE : \KVSun\DOMAIN . \KVSun\STYLE,
+		'href' => \KVSun\DOMAIN . \KVSun\DEV_STYLE,
 	]);
 
 	foreach(\KVSun\SCRIPTS as $script) {

--- a/components/head.php
+++ b/components/head.php
@@ -83,13 +83,13 @@ return function (\shgysk8zer0\DOM\HTML $dom, \shgysk8zer0\Core\PDO $pdo, $page)
 		foreach ($manifest->icons as $icon) {
 			$head->append('link', null, [
 				'rel' => 'icon',
-				'href' => \KVSun\DOMAIN . ltrim($icon->src, '/'),
+				'href' => \KVSun\DOMAIN . trim($icon->src, '/'),
 				'sizes' => $icon->sizes,
 				'type' => $icon->type
 			]);
 			$head->append('link', null, [
 				'rel' => 'apple-touch-icon',
-				'href' => \KVSun\DOMAIN . ltrim($icon->src, '/'),
+				'href' => \KVSun\DOMAIN . trim($icon->src, '/'),
 				'sizes' => $icon->sizes,
 				'type' => $icon->type
 			]);

--- a/components/head.php
+++ b/components/head.php
@@ -83,13 +83,13 @@ return function (\shgysk8zer0\DOM\HTML $dom, \shgysk8zer0\Core\PDO $pdo, $page)
 		foreach ($manifest->icons as $icon) {
 			$head->append('link', null, [
 				'rel' => 'icon',
-				'href' => \KVSun\DOMAIN . $icon->src,
+				'href' => \KVSun\DOMAIN . ltrim($icon->src, '/'),
 				'sizes' => $icon->sizes,
 				'type' => $icon->type
 			]);
 			$head->append('link', null, [
 				'rel' => 'apple-touch-icon',
-				'href' => \KVSun\DOMAIN . $icon->src,
+				'href' => \KVSun\DOMAIN . ltrim($icon->src, '/'),
 				'sizes' => $icon->sizes,
 				'type' => $icon->type
 			]);

--- a/components/nav.php
+++ b/components/nav.php
@@ -20,7 +20,7 @@ return function (\shgysk8zer0\DOM\HTML $dom, \shgysk8zer0\Core\PDO $pdo, $page)
 	}
 	$avatar = $nav->append('img', null, [
 		'id' => 'user-avatar',
-		'src' => 'images/octicons/lib/svg/sign-in.svg',
+		'src' => \KVSun\DOMAIN . '/images/octicons/lib/svg/sign-in.svg',
 		'width' => 64,
 		'height' => 64,
 		'class' => 'round',

--- a/functions.php
+++ b/functions.php
@@ -334,6 +334,55 @@ function use_icon(
 }
 
 /**
+ * Creates a basic navigation menu for $parent
+ * @param  DOMElement   $parent The element to append it to
+ * @return DOMElement   The newly created menu
+ */
+function nav_menu(\DOMElement $parent)
+{
+	$pdo = Core\PDO::load(DB_CREDS);
+	$cats = $pdo('SELECT `name`, `url-name` AS `anchor` FROM `categories`;');
+	$menu = $parent->append('menu', null, [
+		'id' => 'nav_menu',
+		'type' => 'context',
+	]);
+
+	$parent->contextmenu = $menu->id;
+
+	$menu->append('menuitem', null, [
+		'label' => 'Login',
+		'icon' => DOMAIN . '/images/octicons/lib/svg/sign-in.svg',
+		'data-show-modal' => '#login-dialog',
+	]);
+
+	$nav = $menu->append('menu', null, [
+		'label' => 'Page navigation',
+	]);
+
+	$nav->append('menuitem', null, [
+		'label' => 'Top',
+		'icon' => DOMAIN . '/images/octicons/lib/svg/link.svg',
+		'data-scroll-to' => 'body > header',
+	]);
+
+	foreach ($cats as $cat) {
+		$nav->append('menuitem', null, [
+			'label' => $cat->name,
+			'icon' => DOMAIN . '/images/octicons/lib/svg/link.svg',
+			'data-scroll-to' => "#{$cat->anchor}",
+		]);
+	}
+
+	$nav->append('menuitem', null, [
+		'label' => 'Bottom',
+		'icon' => DOMAIN . '/images/octicons/lib/svg/link.svg',
+		'data-scroll-to' => 'body > footer',
+	]);
+
+	return $menu;
+}
+
+/**
  * [load description]
  * @param  Array $files  file1, file2, ...
  * @return Array         [description]

--- a/index.php
+++ b/index.php
@@ -40,6 +40,8 @@ if (@file_exists(DB_CREDS) or !Core\PDO::load(DB_CREDS)->connected) {
 		HTML_TEMPLATES
 	);
 
+	nav_menu($dom->body);
+
 	// Close `<div>` created in [if IE]
 	$dom->body->ifIE('</div>');
 

--- a/stylesheets/styles/aside.css
+++ b/stylesheets/styles/aside.css
@@ -3,7 +3,11 @@ aside {
 	flex-basis: calc(100% - var(--main-width));
 	background: #efefef;
 	border: 2px outset #222;
-	height: 90vh;
-	position: sticky;
-	top: 10vh;
+}
+@media (min-width: 800px) {
+	aside {
+		height: 90vh;
+		position: sticky;
+		top: 10vh;
+	}
 }


### PR DESCRIPTION
## Do not size/position sidebar on mobile. Fixes #51 

### List of significant changes made
-  Set `size` & `position` styles within an `@media`
-  Always use dev stylesheet until Myth is fixed
- Add navigation menu to `<body>`
- Update various icon paths

