### PR TITLE
Throw an error in a catch statement in the fetch Promise

### DIFF
--- a/scripts/kvsapi.es6
+++ b/scripts/kvsapi.es6
@@ -31,7 +31,9 @@ export function popstate(pop) {
 function updatePage(resp) {
 	const type = resp.headers.get('Content-Type');
 	if (type === 'application/json') {
-		return resp.json().then(update);
+		return resp.json().then(update).catch(error => {
+			throw new Error(error);
+		});
 	} else {
 		throw new Error(`Unsupported Content-Type, ${type}`);
 	}


### PR DESCRIPTION
## Fix Chrome compatibility with KVSAPI. Fixes #63

### List of significant changes made
-  Throw error in `updatePage` in a `catch` for `update` 
-  

