### PR TITLE
Disable npm install in webhook

### DIFF
--- a/webhook.php
+++ b/webhook.php
@@ -41,7 +41,6 @@ try {
 					echo `git pull`;
 					$status = `git status`;
 					echo $status . PHP_EOL;
-					`npm install`;
 					$email->message = $status;
 					$email->send();
 				}


### PR DESCRIPTION
Disable `npm install` in `webhook.php` and rely on Git's `post-merge` script. Fixes #83 