### PR TITLE
Update PHP version requirements

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,7 +5,7 @@ php_flag display_errors off
 php_flag html_errors off
 php_flag log_errors on
 <IfModule env_module>
-	SetEnv MIN_PHP_VERSION 5.6
+	SetEnv MIN_PHP_VERSION 7.0
 </IfModule>
 #Configure PHP's autoloader and set include_path, min PHP version
 <IfModule headers_module>

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ language: php
 sudo: required
 dist: trusty
 php:
-  - '5.6'
   - '7.0'
 node_js:
   - 'node'
 env:
   global:
-    - MIN_PHP_VERSION="5.6"
+    - MIN_PHP_VERSION="7.0"
 before_script:
   npm install
 script: npm test

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/KVSun/kvsun.com/issues"
   },
   "engines": {
-    "php": ">=5.6",
+    "php": ">=7.0",
     "npm": ">=4.2"
   },
   "scripts": {


### PR DESCRIPTION
Now requires PHP >= 7.0

## Require PHP >= 7.0. Fixes #90 

### List of significant changes made
-  Update `MIN_PHP_VERSION`
-  Also update in `package.json` & `.travis.yml`

