### PR TITLE
Replace Myth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /pages/e-edition
 /images/uploads/*
 *.sql
-*.js.map
+*.map
 *.rss
 /tags
 /my-httpd.pp

--- a/components/head.php
+++ b/components/head.php
@@ -117,7 +117,9 @@ return function (
 	$head->append('link', null, [
 		'rel' => 'stylesheet',
 		'type' => 'text/css',
-		'href' => \KVSun\DOMAIN . \KVSun\DEV_STYLE,
+		'href' => \KVSun\DEBUG
+			? \KVSun\DOMAIN . \KVSun\DEV_STYLE
+			: \KVSun\DOMAIN . \KVSun\STYLE,
 	]);
 
 	foreach(\KVSun\SCRIPTS as $script) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kv-sun",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Kern Valley Sun",
   "keywords": [
     "kvsun",
@@ -26,11 +26,11 @@
     "npm": ">=3.10"
   },
   "scripts": {
-    "build:css": "myth stylesheets/styles/import.css -c stylesheets/styles/styles.css",
+    "build:css": "postcss stylesheets/styles/import.css -o stylesheets/styles/styles.css -u postcss-import postcss-url postcss-cssnext cssnano -m",
     "build:js": "webpack",
     "build:icons": "svg-sprite-generate -c images/icons.csv -o images/icons.svg",
     "build:ctags": "ctags --langmap='php:.php,javascript:.es6' --exclude='*.js' --exclude='node_modules/' --exclude='vendor/' --exclude='stylesheets/' -h '.php.es6' -R",
-    "build:all": "npm run build:icons && npm run build:js",
+    "build:all": "npm run build:icons && npm run build:css && npm run build:js",
     "lint:js": "eslint --ext .es6 scripts/",
     "lint:php": "php unit.php",
     "git:fetch": "git fetch --all --prune --tags",
@@ -41,17 +41,24 @@
     "postinstall": "npm run update-packages"
   },
   "devDependencies": {
+    "eslint": "^3.7.1",
+    "eslint-plugin-async-await": "0.0.0",
+    "eslint-plugin-babel": "^4.0.1",
+    "svgo": "^0.7.2"
+  },
+  "dependencies": {
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-runtime": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-stage-3": "^6.22.0",
-    "eslint": "^3.7.1",
-    "eslint-plugin-async-await": "0.0.0",
-    "eslint-plugin-babel": "^4.0.1",
-    "myth": "^1.5.0",
+    "cssnano": "^3.10.0",
+    "postcss": "^5.2.14",
+    "postcss-cli": "^3.0.0-beta",
+    "postcss-cssnext": "^2.9.0",
+    "postcss-import": "^9.1.0",
+    "postcss-url": "^5.1.2",
     "svg-sprite-generator": "0.0.1",
-    "svgo": "^0.7.2",
     "webpack": "^1.13.2"
   }
 }


### PR DESCRIPTION
## Replace Myth with postcss-cssnext. Closes #118

### List of significant changes made
- Switch from Myth to postcss-cssnext for transpiling stylesheets
- Ignore all `.map` files
- Update NPM scripts

