### PR TITLE
Feature/36

### DIFF
--- a/api.php
+++ b/api.php
@@ -18,6 +18,7 @@ use \shgysk8zer0\Login\{User};
 use function \KVSun\Functions\{
 	user_can,
 	restore_login,
+	email,
 	get_categories,
 	delete_comments,
 	user_update_form,

--- a/components/handlers/form.php
+++ b/components/handlers/form.php
@@ -26,6 +26,7 @@ use \shgysk8zer0\Core_API\{Abstracts\HTTPStatusCodes as HTTP};
 use function \KVSun\Functions\{
 	restore_login,
 	user_can,
+	email,
 	post_comment,
 	category_exists,
 	make_category,

--- a/consts.php
+++ b/consts.php
@@ -24,6 +24,7 @@ const EXCEPTION_HANDLER = '\shgysk8zer0\Core\Listener::exception';
 const ERROR_HANDLER = '\shgysk8zer0\Core\Listener::error';
 const ERROR_LOG = 'errors.log';
 const EXCEPTION_LOG = 'exceptions.log';
+const CRLF = "\r\n";
 
 const DATE_FORMAT = 'D. M j, Y \a\t h:m:s A';
 const DATETIME_FORMAT = \DATETIME::W3C;

--- a/functions.php
+++ b/functions.php
@@ -79,7 +79,7 @@ function html_email(
 	Array $headers = array('From' => 'no-reply@' . DOMAIN)
 ): Bool
 {
-	$headers['Content-Type'] = ['text/html', 'charset' => $message->actualEncoding];
+	$headers['Content-Type'] = "text/html;charset={$message->actualEncoding}";
 	return email($to, $subject, $message->saveHTML(), $headers);
 }
 

--- a/functions.php
+++ b/functions.php
@@ -65,6 +65,25 @@ function build_dom(Array $path = array()): \DOMDocument
 }
 
 /**
+ * Wrapper function for `mail` as HTML
+ * @param  Array       $to      ["user1@domain.com", ...]
+ * @param  String      $subject Subject of the email to be sent
+ * @param  DOMDocuemnt $message Body of the email as a DOMDocuemnt
+ * @param  array       $headers ['From' => 'admin@domain.com', ...]
+ * @return Bool                 Whether or not the email sent
+ */
+function html_email(
+	Array $to,
+	String $subject,
+	\DOMDocument $message,
+	Array $headers = array('From' => 'no-reply@' . DOMAIN)
+): Bool
+{
+	$headers['Content-Type'] = ['text/html', 'charset' => $message->actualEncoding];
+	return email($to, $subject, $message->saveHTML(), $headers);
+}
+
+/**
  * Wrapper function for `mail`
  * @param  Array  $to      ["user1@domain.com", ...]
  * @param  String $subject Subject of the email to be sent
@@ -72,7 +91,12 @@ function build_dom(Array $path = array()): \DOMDocument
  * @param  array  $headers ['From' => 'admin@domain.com', ...]
  * @return Bool            Whether or not the email sent
  */
-function email(Array $to, String $subject, String $message, Array $headers = array()): Bool
+function email(
+	Array $to,
+	String $subject,
+	String $message,
+	Array $headers = array('From' => 'no-reply@' . DOMAIN)
+): Bool
 {
 	$headers = array_map(function(String $name, String $value): String
 	{

--- a/mail.php
+++ b/mail.php
@@ -6,6 +6,10 @@ use \shgysk8zer0\Core_API\{Abstracts\HTTPStatusCodes as HTTP};
 
 use const \KVSun\Consts\{PUBLIC_KEY, ERROR_LOG};
 
+if (in_array(PHP_SAPI, ['cli', 'cli-server'])) {
+	require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoloader.php';
+}
+
 try {
 	$email = new \ArrayObject($_POST, \ArrayObject::ARRAY_AS_PROPS);
 	if (isset(

--- a/mail.php
+++ b/mail.php
@@ -1,0 +1,50 @@
+<?php
+namespace KVSun\Mail;
+
+use \shgysk8zer0\PHPCrypt\{PublicKey};
+use \shgysk8zer0\Core_API\{Abstracts\HTTPStatusCodes as HTTP};
+
+use const \KVSun\Consts\{PUBLIC_KEY};
+
+try {
+	$email = new \ArrayObject($_POST, \ArrayObject::ARRAY_AS_PROPS);
+	if (isset(
+		$email,
+		$email->to,
+		$email->subject,
+		$email->message,
+		$email->headers,
+		$email->params,
+		$email->sent,
+		$email->sig
+	)) {
+		$public = PublicKey::importFromFile(PUBLIC_KEY);
+
+		if ($public->verify(json_encode([
+			'to'      => $email->to,
+			'subject' => $email->subject,
+			'message' => $email->message,
+			'headers' => $email->headers,
+			'params'  => $email->params,
+			'sent'    => $email->sent,
+		]), $email->sig)) {
+			$sent = strtotime($email->sent);
+			if ($sent > strtotime('+5 seconds') or $sent < strtotime('-5 seconds')) {
+				throw new \Exception('Valid signature but time window is invalid', HTTP::REQUEST_TIMEOUT);
+			} else {
+				if (mail($email->to, $email->subject, $email->message, $email->headers, $email->params)) {
+					http_response_code(HTTP::OK);
+				} else {
+					http_response_code(HTTP::INTERNAL_SERVER_ERROR);
+				}
+			}
+		} else {
+			throw new \Exception('Invalid signature', HTTP::UNAUTHORIZED);
+		}
+	} else {
+		throw new \Exception('Invalid request', HTTP::BAD_REQUEST);
+	}
+} catch (\Throwable $e) {
+	trigger_error("<{$_SERVER['REMOTE_ADDR']}>:" . $e->getMessage());
+	http_response_code($e->getCode() ?? HTTP::INTERNAL_SERVER_ERROR);
+}

--- a/mail.php
+++ b/mail.php
@@ -4,7 +4,7 @@ namespace KVSun\Mail;
 use \shgysk8zer0\PHPCrypt\{PublicKey};
 use \shgysk8zer0\Core_API\{Abstracts\HTTPStatusCodes as HTTP};
 
-use const \KVSun\Consts\{PUBLIC_KEY};
+use const \KVSun\Consts\{PUBLIC_KEY, ERROR_LOG};
 
 try {
 	$email = new \ArrayObject($_POST, \ArrayObject::ARRAY_AS_PROPS);
@@ -45,6 +45,12 @@ try {
 		throw new \Exception('Invalid request', HTTP::BAD_REQUEST);
 	}
 } catch (\Throwable $e) {
-	trigger_error("<{$_SERVER['REMOTE_ADDR']}>:" . $e->getMessage());
+	$err = sprintf(
+		'<%s>: "%s"%s',
+		$_SERVER['REMOTE_ADDR'],
+		$e->getMessage(),
+		PHP_EOL . json_encode(['Request' => $_POST], JSON_PRETTY_PRINT) . PHP_EOL
+	);
+	error_log($err . PHP_EOL, 3, ERROR_LOG);
 	http_response_code($e->getCode() ?? HTTP::INTERNAL_SERVER_ERROR);
 }


### PR DESCRIPTION
## Add wrapper functions for `mail`. Closes #36

### List of significant changes made
-  Add temporary replacement for native `mail` function, `KVSun\Functions\mail`
-  Add wrapper functions `KVSun\Functions\{email, html_email}` to make sending emails easier, and to allow regular emails to be sent simply by removing `KVSun\Functions\mail`
- Make `\KVSun\Functions\email` available in `api.php` & `components/handlers.form.php`
Defines `KVSun\Consts\CRLF` as "\r\n"

