### PR TITLE
Add `mail` wrapper functions and temporary replacement

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -79,7 +79,8 @@ function html_email(
 	Array $headers = array('From' => 'no-reply@' . DOMAIN)
 ): Bool
 {
-	$headers['Content-Type'] = "text/html;charset={$message->actualEncoding}";
+	$encoding = $messsage->encoding ?? 'utf-8';
+	$headers['Content-Type'] = "text/html;charset={$encoding}";
 	return email($to, $subject, $message->saveHTML(), $headers);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kv-sun",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Kern Valley Sun",
   "keywords": [
     "kvsun",


### PR DESCRIPTION
## Add wrapper functions for `mail`. Closes #36

### List of significant changes made
-  Add temporary replacement for native `mail` function, `KVSun\Functions\mail`
-  Add wrapper functions `KVSun\Functions\{email, html_email}` to make sending emails easier, and to allow regular emails to be sent simply by removing `KVSun\Functions\mail`
- Make `\KVSun\Functions\email` available in `api.php` & `components/handlers.form.php`
Defines `KVSun\Consts\CRLF` as "\r\n"