### PR TITLE
Check user permissions and if article requires subscription

### DIFF
--- a/api.php
+++ b/api.php
@@ -58,8 +58,22 @@ if ($header->accept === 'application/json') {
 			$page = new Home(PDO::load(DB_CREDS), "$url", get_categories('url'));
 		} elseif (count($path) === 1) {
 			$page = new Category(PDO::load(DB_CREDS), "$url");
-		} else {
+		} elseif (count($path) === 2) {
 			$page = new Article(PDO::load(DB_CREDS), "$url");
+			if (! $page->is_free and ! user_can('paidArticles')) {
+				$resp->notify(
+					'You must be a subscriber to view this content',
+					'Please login to continue.',
+					ICONS['sign-in']
+				)->showModal('#login-dialog')
+				->send();
+			}
+		} else {
+			$resp->notify(
+				'Invalid request',
+				"No content for {$url}",
+				DOMAIN . ICONS['circle-slash']
+			)->send();
 		}
 
 		exit(json_encode($page));

--- a/components/sections/article.php
+++ b/components/sections/article.php
@@ -6,9 +6,14 @@ use \shgysk8zer0\Core\{PDO};
 use \KVSun\KVSAPI\{Comments, Abstracts\Content as KVSAPI};
 
 use const \KVSun\Consts\{DOMAIN, DATE_FORMAT, DATETIME_FORMAT, LOGO};
+use function \KVSun\Functions\{user_can};
 
 return function (HTML $dom, PDO $pdo, KVSAPI $kvs)
 {
+	if (! $kvs->is_free and ! user_can('paidArticles')) {
+		// #TODO need 404 pages (#123)
+		return;
+	}
 	if (isset($kvs, $kvs->content, $kvs->posted, $kvs->title, $kvs->category)) {
 		$main = $dom->getElementsByTagName('main')->item(0);
 		$template = $dom->getElementById('article-template');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kv-sun",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Kern Valley Sun",
   "keywords": [
     "kvsun",

--- a/scripts/kvsapi.es6
+++ b/scripts/kvsapi.es6
@@ -1,3 +1,4 @@
+import handleJSON from './std-js/json_response.es6';
 const REQUIRED = [
 	'type',
 	'data',
@@ -97,7 +98,9 @@ function update(json) {
 		history.pushState(json, getTitle(json), url);
 		return updateContent(json);
 	} else {
-		throw new Error('Response did not contain type and data.');
+		console.log(json);
+		handleJSON(json);
+		// throw new Error('Response did not contain type and data.');
 	}
 }
 


### PR DESCRIPTION
## Restrict user access to non-free content. Fixes #133 

### List of significant changes made
-  Add user permission and article `is_free` checks
-  Use `handleJSON` in `kvsapi` if not regular content (allows notifications and showing login dialog)
- Add notification if user attempts to visit invalid URL

