### PR TITLE
Update subscriptions

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -105,7 +105,7 @@ AddDefaultCharset utf-8
 # These files may be left by some text editors and can pose a great security
 # danger when anyone has access to them.
 
-<FilesMatch "(^#.*|~.*|\.(bak|ht.*|dav|conf(ig)?|dist|fla|inc|ini|log|psd|sql|sw[op]|asc|(ba)?sh|md|yml|lock|log|git.*|gpg|pgp))$">
+<FilesMatch "(^#.*|~.*|\.(bak|ht.*|dav|conf(ig)?|dist|fla|inc|ini|log|psd|sql|sw[op]|asc|(ba)?sh|md|yml|lock|log|git.*|gpg|pgp|pem))$">
 	Require all denied
 </FilesMatch>
 <FilesMatch "(autoloader|consts|unit|functions).php$">
@@ -214,6 +214,7 @@ AddDefaultCharset utf-8
 	ExpiresByType audio/ogg								"access plus 1 month"
 	ExpiresByType image/gif								"access plus 1 month"
 	ExpiresByType image/jpeg							"access plus 1 month"
+	ExpiresByType image/webp							"access plus 1 month"
 	ExpiresByType image/png								"access plus 1 month"
 	ExpiresByType video/mp4								"access plus 1 month"
 	ExpiresByType video/ogg								"access plus 1 month"

--- a/.htaccess
+++ b/.htaccess
@@ -164,10 +164,10 @@ AddDefaultCharset utf-8
 # be removed: http://developer.yahoo.com/performance/rules.html#etags.
 
 # `FileETag None` is not enough for every server.
-<IfModule headers_module>
-	Header unset ETag
-</IfModule>
-FileETag None
+# <IfModule headers_module>
+# 	Header unset ETag
+# </IfModule>
+# FileETag None
 
 # ------------------------------------------------------------------------------
 # | Expires headers (for better cache control)								 |

--- a/api.php
+++ b/api.php
@@ -104,10 +104,11 @@ if ($header->accept === 'application/json') {
 
 			case 'author_list':
 				$pdo = PDO::load(DB_CREDS);
-				$stm = $pdo->prepare('SELECT `name`
+				$stm = $pdo->prepare('SELECT DISTINCT(`name`)
 					FROM `user_data`
 					JOIN `subscribers` ON `subscribers`.`id` = `user_data`.`id`
-					WHERE `subscribers`.`status` <= :role;'
+					WHERE `subscribers`.`status` <= :role
+					UNION SELECT DISTINCT(`author`) FROM `posts`;'
 				);
 				$stm->role = get_role_id('freelancer');
 				$authors = $stm->execute()->getResults();
@@ -180,7 +181,7 @@ if ($header->accept === 'application/json') {
 
 					$resp->showModal('#login-dialog');
 					$resp->send();
-				} elseif ($user->hasPermission('paidArticles') or true) {
+				} elseif ($user->hasPermission('paidArticles') and ! DEBUG) {
 					$resp->notify(
 						'You do not need to subscribe',
 						"Your subscription has not yet expired",

--- a/autoloader.php
+++ b/autoloader.php
@@ -80,12 +80,6 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 
 function set_path(Array $path, Bool $use_existing = true): String
 {
-	if (
-		in_array(PHP_SAPI, ['cli', 'cli-server'])
-		or $_SERVER['SERVER_ADDR'] === $_SERVER['REMOTE_ADDR']
-	) {
-		array_unshift($path, '..');
-	}
 	$path = array_map('realpath', $path);
 	$path = join(\PATH_SEPARATOR, $path);
 	if ($use_existing === true) {

--- a/components/handlers/form.php
+++ b/components/handlers/form.php
@@ -9,6 +9,7 @@ use \shgysk8zer0\Core\{
 	Listener,
 	Headers,
 	URL,
+	HTTPException,
 	Gravatar
 };
 use \shgysk8zer0\DOM\{HTML};
@@ -1017,7 +1018,7 @@ switch($req->form) {
 				'expires' => $expires->format($expires::W3C),
 			]);
 			if ($subscribe->rowCount() === 1) {
-				throw new \Exception('There was an error saving your subscription');
+				throw new HTTPException('There was an error saving your subscription', 200);
 			}
 			$response = $request();
 
@@ -1072,11 +1073,12 @@ switch($req->form) {
 					);
 				}
 			} else {
-				throw new \Exception($response);
+				throw new HTTPException($response, 200);
 			}
 
-		} catch (\Exception $e) {
+		} catch (HTTPException $e) {
 			$pdo->rollBack();
+			http_response_code($e->getCode());
 			$resp->notify(
 				'There was an error processing your payment',
 				$e->getMessage(),

--- a/components/handlers/form.php
+++ b/components/handlers/form.php
@@ -1035,6 +1035,7 @@ switch($req->form) {
 
 			if ($response->code == '1') {
 				$pdo->commit();
+				Listener::userSubscribed($user, $sub, $shipping);
 				$record = $pdo->prepare(
 					'INSERT INTO `transactions` (
 						`transactionID`,
@@ -1062,16 +1063,6 @@ switch($req->form) {
 					ICONS['credit-card'],
 					true
 				);
-
-				if ($sub->print) {
-					# @todo Create a useful email
-					email(
-						['circulation@kvsun.com'],
-						"New online print subscription for {$req->ccform->card->name}",
-						'',
-						['From' => 'no-reply@kvsun.com']
-					);
-				}
 			} else {
 				throw new HTTPException($response, 200);
 			}

--- a/components/handlers/form.php
+++ b/components/handlers/form.php
@@ -938,29 +938,29 @@ switch($req->form) {
 			$sub->online = $sub->online === '1';
 			$sub->pdf    = $sub->pdf    === '1';
 
-			// if (
-			// 	$sub->print
-			// 	and $sub->local
-			// 	and ! in_array(intval($req->ccform->billing->zip), LOCAL_ZIPS)
-			// ) {
-			// 	$resp->notify(
-			// 		'You do not qualify for this subscription',
-			// 		'Please select from our out of Valley print subscriptions',
-			// 		ICONS['credit-card'],
-			// 		true
-			// 	)->focus('#ccform-subscription')->send();
-			// } elseif (
-			// 	$sub->print
-			// 	and !$sub->local
-			// 	and in_array(intval($req->ccform->billing->zip), LOCAL_ZIPS)
-			// ) {
-			// 	$resp->notify(
-			// 		'You do not qualify for this subscription',
-			// 		'Please select from our local print subscriptions',
-			// 		ICONS['credit-card'],
-			// 		true
-			// 	)->focus('#ccform-subscription')->send();
-			// }
+			if (
+				$sub->print
+				and $sub->local
+				and ! in_array(intval($req->ccform->billing->zip), LOCAL_ZIPS)
+			) {
+				$resp->notify(
+					'You do not qualify for this subscription',
+					'Please select from our out of Valley print subscriptions',
+					ICONS['credit-card'],
+					true
+				)->focus('#ccform-subscription')->send();
+			} elseif (
+				$sub->print
+				and !$sub->local
+				and in_array(intval($req->ccform->billing->zip), LOCAL_ZIPS)
+			) {
+				$resp->notify(
+					'You do not qualify for this subscription',
+					'Please select from our local print subscriptions',
+					ICONS['credit-card'],
+					true
+				)->focus('#ccform-subscription')->send();
+			}
 
 			$creds = Credentials::loadFromIniFile(AUTHORIZE, DEBUG);
 			$expires = new \DateTime(

--- a/default.sql
+++ b/default.sql
@@ -78,7 +78,7 @@ DROP TABLE IF EXISTS `images`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `images` (
-  `id` int(5) NOT NULL AUTO_INCREMENT,
+  `id` int(10) NOT NULL AUTO_INCREMENT,
   `path` varchar(80) NOT NULL,
   `fileFormat` varchar(12) NOT NULL DEFAULT 'image/jpeg',
   `contentSize` int(12) NOT NULL,
@@ -91,7 +91,7 @@ CREATE TABLE `images` (
   `uploadedBy` int(13) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `imgPath` (`path`)
-) ENGINE=InnoDB AUTO_INCREMENT=32 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=100 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -152,7 +152,7 @@ CREATE TABLE `post_comments` (
   `approved` tinyint(1) NOT NULL DEFAULT '0',
   `text` longtext NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -173,13 +173,13 @@ CREATE TABLE `posts` (
   `draft` tinyint(1) NOT NULL DEFAULT '0',
   `isFree` tinyint(1) NOT NULL DEFAULT '1',
   `url` varchar(120) NOT NULL,
-  `img` varchar(80) DEFAULT NULL,
+  `img` int(10) DEFAULT NULL,
   `posted_by` int(3) NOT NULL COMMENT 'User ID',
   `keywords` varchar(120) DEFAULT NULL,
   `description` varchar(160) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `url` (`url`)
-) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=31 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -212,7 +212,7 @@ CREATE TABLE `srcset` (
   `format` varchar(15) NOT NULL DEFAULT 'image/jpeg',
   `filesize` int(6) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=274 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -228,7 +228,7 @@ CREATE TABLE `subscribers` (
   `sub_expires` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `sub_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=964 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -242,12 +242,15 @@ CREATE TABLE `subscription_rates` (
   `id` int(2) NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL,
   `description` varchar(255) NOT NULL,
-  `media` enum('online','e-edition','print') NOT NULL DEFAULT 'online',
+  `term` varchar(7) NOT NULL,
   `price` decimal(5,2) NOT NULL,
+  `role` int(3) NOT NULL,
+  `isUpgrade` tinyint(1) NOT NULL DEFAULT '0',
   `isLocal` tinyint(1) NOT NULL DEFAULT '0',
+  `includesPrint` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
+  UNIQUE KEY `name` (`name`,`term`)
+) ENGINE=InnoDB AUTO_INCREMENT=19 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -300,7 +303,7 @@ CREATE TABLE `users` (
   `username` varchar(50) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `user` (`email`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1 ROW_FORMAT=COMPACT;
+) ENGINE=InnoDB AUTO_INCREMENT=964 DEFAULT CHARSET=latin1 ROW_FORMAT=COMPACT;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -312,4 +315,4 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-02-27 16:48:00
+-- Dump completed on 2017-03-03 11:47:37

--- a/functions.php
+++ b/functions.php
@@ -148,6 +148,9 @@ function mail(
 			'sent'    => $time->format(\Datetime::W3C),
 		];
 		$email['sig'] = $private->sign(json_encode($email));
+		if (DEBUG) {
+			return true;
+		}
 
 		curl_setopt_array($ch, [
 			CURLOPT_RETURNTRANSFER => false,

--- a/functions.php
+++ b/functions.php
@@ -935,52 +935,39 @@ function make_cc_form(HTMLElement $parent = null, String $name = 'ccform'): \DOM
 		'id' => "{$form->name}-subscription",
 	]);
 
-	$online = $input->append('optgroup', null, ['label' => 'Online subscriptions']);
-	$print_local = $input->append('optgroup', null, ['label' => 'Print subscriptions']);
-	$e_edition = $input->append('optgroup', null, ['label' => 'E-Edition subscriptions']);
-	$print_oov = $input->append('optgroup', null, ['label' => 'Out of Valley print subscriptions']);
-
 	$pdo = PDO::load(DB_CREDS);
 	try {
 		$subs = $pdo(
 			'SELECT
 			`id`,
 			`name`,
-			`media`,
+			`term`,
 			`price`,
 			`isLocal`
 			FROM `subscription_rates`
+			WHERE `isUpgrade` = 0
 			ORDER BY `price` DESC;'
 		);
 	} catch(\Throwable $e) {
 		trigger_error($e->getMessage());
 	}
 
-	array_map(function(\stdClass $sub) use (
-		$print_local,
-		$print_oov,
-		$e_edition,
-		$online
-	)
+	$groups = [];
+
+	usort($subs, function(\stdClass $sub1, \stdClass $sub2): Int
 	{
-		$option = new \DOMElement('option', "{$sub->name} [\${$sub->price}]");
-		switch($sub->media) {
-			case 'online':
-				$online->appendChild($option);
-				break;
+		return new \DateTime($sub2->term) <=> new \DateTime($sub1->term);
+	});
 
-			case 'e-edition':
-				$e_edition->appendChild($option);
-				break;
-
-			case 'print':
-				if ($sub->isLocal) {
-					$print_local->appendChild($option);
-				} else {
-					$print_oov->appendChild($option);
-				}
-				break;
+	array_map(function(\stdClass $sub) use (&$groups, $input)
+	{
+		if (! array_key_exists($sub->term, $groups)) {
+			$groups[$sub->term] = new \DOMElement('optgroup');
+			$input->appendChild($groups[$sub->term]);
+			$groups[$sub->term]->setAttribute('label', $sub->term);
 		}
+		$option = new \DOMElement('option', "{$sub->name} [\${$sub->price}]");
+		$groups[$sub->term]->appendChild($option);
 		$option->setAttribute('value', $sub->id);
 	}, $subs);
 	$label->for = $input->id;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kv-sun",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Kern Valley Sun",
   "keywords": [
     "kvsun",


### PR DESCRIPTION
## Makes customizing subscriptions much easier. For #119

### List of significant changes made
-  Check user login/subscription status as well as `posts`.`isFree`
-  If user is signed in but cannot view content, show subscriptions form
- If user is not logged in, show login/registration form
- Use `PDO` transactions to prevent updating subscriptions on rejected payments
- Only send payment request if tables have updated (_before `PDO::commit`_)

