### PR TITLE
Add WYSIWYG menu option to embed YouTube videos

### DIFF
--- a/components/menus/wysiwyg.html
+++ b/components/menus/wysiwyg.html
@@ -226,6 +226,7 @@
 	</menu>
 	<menuitem label="Line Break" data-editor-command="inserthtml" data-editor-value="<br />"></menuitem>
 	<menuitem label="Horizontal Rule" icon="images/octicons/lib/svg/horizontal-rule.svg" data-editor-command="inserthorizontalrule"></menuitem>
+	<menuitem label="Embed YouTube video" icon="/images/logos/YouTube.svg" data-embed="youtube"></menuitem>
 	<menu label="Selection">
 		<menuitem label="Select All" data-editor-command="selectall"></menuitem>
 		<menuitem label="Clear Formatting" icon="images/octicons/lib/svg/circle-slash.svg" data-editor-command="removeformat"></menuitem>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kv-sun",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Kern Valley Sun",
   "keywords": [
     "kvsun",


### PR DESCRIPTION
## Add `<menuitem>` to embed YouTube videos from URL. Resolves #156 

### List of significant changes made
-  Update `shgysk8zer/std-js` to import WYSIWYG editor js capability
-  Add `<menuitem>` to `wysiwyg.html`