### PR TITLE
Use own home icon

### DIFF
--- a/images/icons.csv
+++ b/images/icons.csv
@@ -15,7 +15,7 @@ facebook,images/logos/Facebook.svg
 gear,images/octicons/lib/svg/gear.svg
 google+,images/logos/Google_plus.svg
 history,images/octicons/lib/svg/history.svg
-home,images/octicons/lib/svg/home.svg
+home,images/kvs-icons/sections/home.svg
 inbox,images/octicons/lib/svg/inbox.svg
 info,images/octicons/lib/svg/info.svg
 issue-opened,images/octicons/lib/svg/issue-opened.svg


### PR DESCRIPTION
This will work better for style of icons.
CSS does not work on production home octicon for some reason, and switching to this one fixes that.