### PR TITLE
Improve responsive images by setting `sizes` attribute

### DIFF
--- a/components/sidebar.php
+++ b/components/sidebar.php
@@ -71,7 +71,15 @@ function make_rail(\DOMElement $parent, PDO $pdo, Int $limit = 7, Int $size = 25
 			$link = $parent->append('a', null, [
 				'href' => DOMAIN . "{$post->catURL}/{$post->url}",
 			]);
-			$picture->getPicture($post->img, $link);
+			$picture->getPicture(
+				$post->img,
+				$link,
+				[
+					'(max-width: 800px) 100%',
+					'30vw'
+				],
+				false
+			);
 			$link->append('p', "{$post->category} &raquo; {$post->title}");
 			$parent->append('hr');
 		};


### PR DESCRIPTION
## Set `sizes` on `<picture>`s & `<figure>`s

### List of significant changes made
-  Update `KVSun\KVSAPI` (`Picture` class & `Traits\Images` now handle `sizes`)
-  Set custom media query on rail `<picture>`s (Resolves #204 )
- Do not set microdata on rail images (Fixes #201 )

