### PR TITLE
Add mobile navigation as slide-out sidebar

### DIFF
--- a/components/header.php
+++ b/components/header.php
@@ -3,13 +3,21 @@ namespace KVSun\Components\Header;
 
 use \shgysk8zer0\DOM\{HTML};
 use \shgysk8zer0\Core\{PDO};
-use \KVsun\KVSAPI\{Abstracts\Content as KVSAPI};
+use \KVSun\KVSAPI\{Abstracts\Content as KVSAPI};
+use function \KVSun\Functions\{use_icon};
 
 return function (HTML $dom, PDO $pdo, KVSAPI $kvs)
 {
-	$dom->body->append('header')->append('h1', $kvs->getHead()->title, [
+	$header = $dom->body->append('header')->append('h1', $kvs->getHead()->title, [
 		'class' => 'site-title',
 		'role'  => 'banner',
 	]);
-
+	$mobile_toggle = $header->append('button', null, [
+		'data-toggle-class' => '{"#main-nav": "menu-open"}',
+		'class'             => 'mobile-only',
+		'id'                => 'mobile-menu-btn',
+	]);
+	use_icon('hamburger', $mobile_toggle, [
+		'class' => 'icon'
+	]);
 };

--- a/components/nav.php
+++ b/components/nav.php
@@ -19,6 +19,7 @@ return function (HTML $dom, PDO $pdo, KVSAPI $kvs)
 	$nav = $dom->body->append('nav', null, [
 		'role'  => 'navigation',
 		'class' => 'flex sticky',
+		'id'    => 'main-nav',
 	]);
 	$home = $nav->append('a', null, array_merge(ATTRS, [
 		'href'  => DOMAIN,
@@ -60,9 +61,9 @@ return function (HTML $dom, PDO $pdo, KVSAPI $kvs)
 			use_icon($page->icon, $add, [
 				'class' => 'icon',
 			]);
-			if ($url->host !== $_SERVER['HTTP_HOST']) {
-				$add->target = '_blank';
-			}
+			// if ($url->host !== $_SERVER['HTTP_HOST']) {
+			// 	$add->target = '_blank';
+			// }
 		} else {
 			$nav->append('a', $page->name, array_merge(ATTRS, [
 				'href' => DOMAIN . $page->url,

--- a/images/icons.csv
+++ b/images/icons.csv
@@ -14,6 +14,7 @@ credit-card,images/octicons/lib/svg/credit-card.svg
 facebook,images/logos/Facebook.svg
 gear,images/octicons/lib/svg/gear.svg
 google+,images/logos/Google_plus.svg
+hamburger,images/octicons/lib/svg/grabber.svg
 history,images/octicons/lib/svg/history.svg
 home,images/kvs-icons/sections/home.svg
 inbox,images/octicons/lib/svg/inbox.svg

--- a/scripts/eventHandlers.es6
+++ b/scripts/eventHandlers.es6
@@ -4,6 +4,15 @@ import {parseResponse} from './std-js/functions.es6';
 import getPage from './kvsapi.es6';
 import SocialShare from './std-js/socialshare.es6';
 
+export function dataToggleClass() {
+	if (this.dataset.hasOwnProperty('toggleClass')) {
+		let json = JSON.parse(this.dataset.toggleClass);
+		Object.keys(json).forEach(sel => {
+			$(sel).each(el => el.classList.toggle(json[sel]));
+		});
+	}
+}
+
 export function dataShare() {
 	if (this.dataset.hasOwnProperty('share')) {
 		switch(this.dataset.share) {

--- a/scripts/mutations.es6
+++ b/scripts/mutations.es6
@@ -145,6 +145,14 @@ export const watcher = {
 			}
 			break;
 
+		case 'data-toggle-class':
+			if (this.target.dataset.hasOwnProperty('toggleClass')) {
+				this.target.addEventListener('click', eventHandler.dataToggleClass);
+			} else {
+				this.target.removeEventListener('click', eventHandler.dataToggleClass);
+			}
+			break;
+
 		default:
 			console.error(`Unhandled attribute in watch: "${this.attributeName}"`);
 		}
@@ -170,7 +178,8 @@ export const attributeTree = [
 	'data-request',
 	'data-share',
 	'data-fullscreen',
-	'data-admin'
+	'data-admin',
+	'data-toggle-class'
 ];
 
 export function bootstrap() {
@@ -233,6 +242,9 @@ export function bootstrap() {
 		});
 		query('[data-delete]', node).forEach(el => {
 			el.addEventListener('click', eventHandler.dataDelete);
+		});
+		query('[data-toggle-class]', node).forEach(el => {
+			el.addEventListener('click', eventHandler.dataToggleClass);
 		});
 		query('[data-admin]', node).forEach(el => {
 			if (Admin[el.dataset.admin] instanceof Function) {

--- a/stylesheets/styles/nav.css
+++ b/stylesheets/styles/nav.css
@@ -1,24 +1,72 @@
-body > nav {
-	order: 1;
-	padding: var(--nav-padding) 0;
-	top: 0;
-	z-index: 2;
+@media (min-width: 801px) {
+	body > nav {
+		order: 1;
+		padding: var(--nav-padding) 0;
+		top: 0;
+		z-index: 2;
+	}
+		body > nav > :not(#user-avatar) {
+		height: var(--nav-height);
+		border-radius: 0 1rem 0 0;
+		flex-grow: 1;
+		text-align: center;
+		background: var(--primary-color);
+	}
+	#user-avatar {
+		width: var(--nav-height);
+		height: var(--nav-height);
+	}
 }
-body > nav > :not(#user-avatar) {
-	height: var(--nav-height);
-	border-radius: 0 1rem 0 0;
-	flex-grow: 1;
-	text-align: center;
-	background: var(--primary-color);
-}
-#user-avatar {
-	width: var(--nav-height);
-	height: var(--nav-height);
-}
+
 [itemprop="breadcrumb"] [itemprop="itemListElement"] {
 	padding: 0.3em;
 	display: inline-block;
 }
 [itemprop="breadcrumb"] [itemprop="itemListElement"]:not(:last-child)::after {
 	content: "»";
+}
+@media (max-width: 800px) {
+	body > nav {
+		position: fixed;
+		top: 0;
+		transform: translateX(-30vw);
+		height: 100vh;
+		width: 30vw;
+		flex-basis: 15vw;
+		flex-grow: 0;
+		background-image: var(--glass-grad);
+		flex-direction: column;
+		transition: transform 300ms;
+	}
+	body > nav > a:not(#user-avatar) {
+		order: 1;
+	}
+	body > nav > a::after {
+		content: attr(title);
+		display: inline;
+		font-family: inherit;
+		overflow-wrap: break-word;
+	}
+	#user-avatar {
+		order: 0;
+		width: var(--nav-height);
+		height: var(--nav-height);
+	}
+	body > nav.menu-open {
+		transform: none;
+		box-shadow: var(--shadow);
+	}
+	#mobile-menu-btn {
+		position: fixed;
+		display: inline-flex;
+		align-items: center;
+		top: 0.3rem;
+		right: 0.3rem;
+		background-color: #dedede;
+		height: 3.8rem;
+		width: 3.8rem;
+		border-radius: 0.3rem;
+		border: 0.1rem solid #222;
+		opacity: 0.8;
+	}
 }

--- a/stylesheets/styles/responsive.css
+++ b/stylesheets/styles/responsive.css
@@ -13,3 +13,8 @@
 		display: none;
 	}
 }
+@media (min-width: 801px) {
+	.mobile-only {
+		display: none;
+	}
+}

--- a/stylesheets/styles/vars.css
+++ b/stylesheets/styles/vars.css
@@ -22,8 +22,8 @@
 	--nav-padding: 0.1rem;
 	/*========== Set background images, etc here ==========*/
 	/*--main-bg: url(../../images/backgrounds/dark_abstract.svgz);*/
-	--glass-grad: linear-gradient(to top left, rgba(80, 80, 80, 0.7), rgba(140, 140, 140, 0.9), rgba(40, 40, 40, 0.7));
-	--shadow: rgba(20, 20, 20, 0.9);
+	--glass-grad: linear-gradient(to top left, rgba(80, 80, 80, 0.8), rgba(140, 140, 140, 0.95), rgba(40, 40, 40, 0.8));
+	--shadow: 0.3rem 0.3rem 0.3rem rgba(20, 20, 20, 0.8);
 	--tint-glass: linear-gradient(rgba(40, 40, 40, 0.8), rgba(80, 80, 80, 0.7));
 	--header-bg: linear-gradient(rgba(40, 40, 40, 1), rgba(80, 80, 80, 0.97));
 	--logo: url(/images/sun-icons/sun-rise.svg);


### PR DESCRIPTION
## Use different navigation styles for mobile

### List of significant changes made
-  Add `data-toggle-class` attribute click handler function
-  Add button to toggle `menu-open` class for `<nav>` on mobile
- Add CSS rule to hide `.mobile-only` on desktop

