### PR TITLE
Use report-uri.io instead of own CSP report URI

### DIFF
--- a/consts.php
+++ b/consts.php
@@ -64,7 +64,7 @@ const CSP          = array(
 	'script-src'   => ["'self'"],
 	'style-src'    => ["'self'", "'unsafe-inline'"],
 	'media-src'    => ['*'],
-	'report-uri'   => '/csp.php',
+	'report-uri'   => 'https://kvsun.report-uri.io/r/default/csp/enforce ',
 );
 
 const HTML_TEMPLATES = [

--- a/csp.php
+++ b/csp.php
@@ -1,8 +1,0 @@
-<?php
-namespace KVSun\CSP;
-use \shgysk8zer0\Core\{Headers, Console};
-$headers = new Headers();
-if (in_array($headers->content_type, ['application/json', 'application/csp-report'])) {
-	$report = json_decode(file_get_contents('php://input'));
-	Console::log($report);
-}


### PR DESCRIPTION
- Remove `csp.php`
- Use report-uri.io for CSP reports