### PR TITLE
Allow admins to change user password

### DIFF
--- a/api.php
+++ b/api.php
@@ -272,6 +272,68 @@ if ($header->accept === 'application/json') {
 				}
 				break;
 
+			case 'admin-user-password':
+				if (user_can('alterUsers')) {
+					$pdo = PDO::load(DB_CREDS);
+					$dialog = make_dialog('user-password-dialog');
+
+					$form = $dialog->append('form', null, [
+						'name'         => 'admin-user-password',
+						'action'       => 'api.php',
+						'method'       => 'post',
+						'autocomplete' => 'off',
+					]);
+
+					$fieldset = $form->append('fieldset');
+					$fieldset->append('legend', 'Update user password');
+
+					$users = $fieldset->append('datalist', null, [
+						'id' => 'user-emails-list',
+					]);
+
+					array_map(
+						function(\stdClass $user) use ($users)
+						{
+							$users->append('option', null, ['value' => "{$user->email}"]);
+						},
+						$pdo('SELECT `email` FROM `users`;')
+					);
+
+					$fieldset->append('label', 'User Email: ')->append('input', null, [
+						'name'         => "{$form->name}[email]",
+						'id'           => "{$form->name}-email",
+						'type'         => 'email',
+						'list'         => $users->id,
+						'placeholder'  => 'user@example.com',
+						'autocomplete' => 'off',
+						'required'     => '',
+					]);
+
+					$fieldset->append('br');
+
+					$fieldset->append('label', 'New Password ')->append('input', null, [
+						'name'        => "{$form->name}[password]",
+						'id'          => "{$form->name}-password",
+						'placeholder' => '*************',
+						'pattern'     => '.{8,}',
+						'required'    => ''
+					]);
+
+					$form->append('br');
+
+					$form->append('button', 'Submit', [
+						'type' => 'submit',
+					]);
+					$resp->append('body', "{$dialog}");
+					$resp->showModal("#{$dialog->id}");
+				} else {
+					$resp->notify(
+						'Unauthorized',
+						'You do not have permission to update user info'
+					);
+				}
+				break;
+
 			default:
 			// All HTML forms in forms/ should be considered publicly available
 				if (@file_exists("./components/forms/{$_REQUEST['load_form']}.html")) {

--- a/components/handlers/form.php
+++ b/components/handlers/form.php
@@ -610,9 +610,11 @@ switch($req->form) {
 				if ($users->updatePassword($creds->password, $creds->email)) {
 					$resp->notify(
 						'Success',
-						"Credentails for {$creds->email} have been updated"
+						"Credentails for {$creds->email} have been updated",
+						ICONS['person']
 					)->remove('#user-password-dialog');
 				} else {
+					http_response_code(HTTP::BAD_REQUEST);
 					$resp->notify(
 						"Update failed",
 						"Either {$creds->email} does not exist or there was a server error",
@@ -620,13 +622,20 @@ switch($req->form) {
 					);
 				}
 			} else {
-				$resp->notify('Missing info');
+				http_response_code(HTTP::BAD_REQUEST);
+				$resp->notify(
+					'Missing or invalid input',
+					'Double check your inputs and try again',
+					ICONS['thumbsdown']
+				);
 				$resp->focus('#admin-user-password-email');
 			}
 		} else {
+			http_response_code(HTTP::UNAUTHORIZED);
 			$resp->notify(
 				'Unauthorized',
-				'You are not allowed to update user info'
+				'You are not allowed to update user info',
+				ICONS['circle-slash']
 			);
 		}
 		break;

--- a/components/handlers/form.php
+++ b/components/handlers/form.php
@@ -598,6 +598,39 @@ switch($req->form) {
 		}
 		break;
 
+	case 'admin-user-password':
+		if (user_can('alterUsers')) {
+			$creds = $req->{'admin-user-password'};
+			if (
+				isset($creds->email, $creds->password)
+				and filter_var($creds->email, FILTER_VALIDATE_EMAIL)
+				and strlen($creds->password) >= 8
+			) {
+				$users = User::load(DB_CREDS);
+				if ($users->updatePassword($creds->password, $creds->email)) {
+					$resp->notify(
+						'Success',
+						"Credentails for {$creds->email} have been updated"
+					)->remove('#user-password-dialog');
+				} else {
+					$resp->notify(
+						"Update failed",
+						"Either {$creds->email} does not exist or there was a server error",
+						ICONS['bug']
+					);
+				}
+			} else {
+				$resp->notify('Missing info');
+				$resp->focus('#admin-user-password-email');
+			}
+		} else {
+			$resp->notify(
+				'Unauthorized',
+				'You are not allowed to update user info'
+			);
+		}
+		break;
+
 	case 'search':
 		$resp->notify('Search results', 'Check console for more info');
 		$pdo = PDO::load(DB_CREDS);

--- a/components/menus/admin.html
+++ b/components/menus/admin.html
@@ -2,4 +2,5 @@
 	<menuitem label="Create Post" data-admin="makePost" icon="/images/octicons/lib/svg/file-text.svg"></menuitem>
 	<menuitem label="Edit Post" data-admin="updatePost" icon="/images/octicons/lib/svg/pencil.svg"></menuitem>
 	<menuitem label="Moderate comments" data-load-form="moderate" icon="/images/octicons/lib/svg/comment-discussion.svg"></menuitem>
+	<menuitem label="Update user" data-load-form="admin-user-password" icon="/images/octicons/lib/svg/person.svg"></menuitem>
 </menu>


### PR DESCRIPTION
## Create forms and handlers for admin access to change user passwords. Fixes #225

### List of significant changes made
-  Add `<menuitem>` to admin contextmenu to load form
-  Create handler to load form, verifying that user has permission to `alterUsers`
- Add handler for form submission, checking `alterUsers` permission and valid input

